### PR TITLE
Update CI/CD script to use modern docker compose syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,5 +23,5 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ secrets.LIGHTSAIL_USER }}@${{ secrets.LIGHTSAIL_HOST }} << 'EOF'
             cd /home/ubuntu/Chat-Royale
             git pull origin main
-            docker-compose -f docker-compose.prod.yml up -d --build
+            docker compose -f docker-compose.prod.yml up -d --build
           EOF


### PR DESCRIPTION
## Summary
- Updated the GitHub Actions deployment workflow to use `docker compose` instead of `docker-compose`
- This aligns with the modern Docker Compose syntax (v2) for better compatibility

## Test plan
- [x] Verify the deployment script syntax is correct
- [ ] Test deployment workflow on merge to main

🤖 Generated with [Claude Code](https://claude.ai/code)