### PR TITLE
Updated CD script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,5 +23,6 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ secrets.LIGHTSAIL_USER }}@${{ secrets.LIGHTSAIL_HOST }} << 'EOF'
             cd /home/ubuntu/Chat-Royale
             git pull origin main
+            docker compose down
             docker compose -f docker-compose.prod.yml up -d --build
           EOF


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Deploy workflow now stops existing containers before rebuilding and starting prod services on Lightsail.
> 
> - **CI/CD (GitHub Actions)**:
>   - Update `/.github/workflows/deploy.yml` deploy step to run `docker compose down` on the Lightsail host before `docker compose -f docker-compose.prod.yml up -d --build`.
>   - Ensures clean restart of services during deployment in `Chat-Royale` directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dae6bdce78baa0ff6df39cac52147622c85a43d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->