### PR TITLE
Fixed a bug in the previously added feature

### DIFF
--- a/src/frontend/src/components/ui/ToolsModal.tsx
+++ b/src/frontend/src/components/ui/ToolsModal.tsx
@@ -9,19 +9,19 @@ interface ToolsModalProps {
 }
 
 const ToolsModal: React.FC<ToolsModalProps> = ({ isOpen, onClose }) => {
-  // Handle escape key
+  // Handle escape key and body scroll
   useEffect(() => {
+    if (!isOpen) return;
+
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
+      if (e.key === 'Escape') {
         onClose();
       }
     };
 
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape);
-      // Prevent body scroll when modal is open
-      document.body.style.overflow = 'hidden';
-    }
+    document.addEventListener('keydown', handleEscape);
+    // Prevent body scroll when modal is open
+    document.body.style.overflow = 'hidden';
 
     return () => {
       document.removeEventListener('keydown', handleEscape);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors `ToolsModal` effect to only run when open, ensuring Escape closes the modal and body scroll is locked/unlocked correctly.
> 
> - **Frontend**
>   - **`src/frontend/src/components/ui/ToolsModal.tsx`**:
>     - Refactors `useEffect` to early-return when `!isOpen`, then add `keydown` listener and lock body scroll only when open.
>     - Simplifies Escape handling by removing redundant `isOpen` check; cleanup restores body overflow and removes listener.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97e18e89b26f0fcf403b3db3f86edca693843a2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->